### PR TITLE
Updated to work with emacs-29

### DIFF
--- a/replace-from-region.el
+++ b/replace-from-region.el
@@ -119,7 +119,7 @@
 		 from nil nil           ;HERE
 		 query-replace-to-history-variable from t)))
        (add-to-history query-replace-to-history-variable to nil t)
-       (push (cons from to) query-replace-defaults)
+       (add-to-history 'query-replace-defaults (cons from to) nil t)
        to))
    regexp-flag))
 


### PR DESCRIPTION
This fixes the error shown on modern versions of emacs when using regular `query-replace` after using `query-replace-from-region` 

```
query-replace-read-args: Wrong type argument: listp, "up"
```
When the last query with `query-replace-from-region` was "up"